### PR TITLE
relax version bounds for TH and hashable, bump LTS number

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,13 +24,13 @@ dependencies:
 - base                 >= 4.11 && < 5
 - containers           >= 0.6  && < 0.7
 - mtl                  >= 2.2  && < 2.3
-- template-haskell     >= 2.14 && < 2.15
+- template-haskell     >= 2.14
 - text                 >= 1.2  && < 1.3
 - transformers         >= 0.5  && < 0.6
 - deepseq              >= 1.4  && < 1.5   # NFData
-- hashable             >= 1.2  && < 1.3
+- hashable             >= 1.2
 - unordered-containers >= 0.2  && < 0.3
-- th-lift              >= 0.7.11 && < 0.8   # Language.Haskell.TH.Lift
+- th-lift              >= 0.7.11  # Language.Haskell.TH.Lift
 - haskell-src-meta     >= 0.8  && < 0.9   # Parsing of G4 directives to TH
 
 #- ghc-prim

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: nightly-2019-04-10
-#resolver: lts-12.19
+# resolver: nightly-2019-04-10
+resolver: lts-16.15
 
 packages:
 - .


### PR DESCRIPTION
Hi, I'm trying to use this library and I relaxed some version bounds for Template Haskell and hashable to make it work with the most recent LTS version on Hackage (16.15). It seems to have the same behavior as the current master branch on my laptop when running ` stack test :simple :atn :ll :lr  :sexpression :allstar :c`.