### PR TITLE
Port antlr-haskell to GHC 9.6.6 / Stackage lts-22.43

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -22,16 +22,16 @@ description:         Please see the README on Github at <https://github.com/cron
 
 dependencies:
 - base                 >= 4.11 && < 5
-- containers           >= 0.6  && < 0.7
-- mtl                  >= 2.2  && < 2.3
-- template-haskell     >= 2.14
-- text                 >= 1.2  && < 1.3
-- transformers         >= 0.5  && < 0.6
-- deepseq              >= 1.4  && < 1.5   # NFData
+- containers           >= 0.6  && < 0.8
+- mtl                  >= 2.2  && < 2.4
+- template-haskell     >= 2.14 && < 2.23
+- text                 >= 1.2  && < 2.2
+- transformers         >= 0.5  && < 0.7
+- deepseq              >= 1.4  && < 1.6
 - hashable             >= 1.2
 - unordered-containers >= 0.2  && < 0.3
 - th-lift              >= 0.7.11  # Language.Haskell.TH.Lift
-- haskell-src-meta     >= 0.8  && < 0.9   # Parsing of G4 directives to TH
+- haskell-src-meta     >= 0.8     # Parsing of G4 directives to TH
 
 #- ghc-prim
 
@@ -80,6 +80,7 @@ library:
     - DeriveDataTypeable
     - DeriveGeneric
     - DeriveAnyClass
+    - StarIsType
 
   # LANGUAGE extensions used by modules in this package.
   other-extensions:

--- a/src/Data/Set/Monad.hs
+++ b/src/Data/Set/Monad.hs
@@ -212,7 +212,6 @@ instance Semigroup (Set a) where
 
 instance (Ord a) => Monoid (Set a) where
   mempty  = empty
-  mappend = union
   mconcat = unions
 
 instance Foldable Set where

--- a/src/Language/ANTLR4/Boot/Quote.hs
+++ b/src/Language/ANTLR4/Boot/Quote.hs
@@ -292,8 +292,10 @@ lookupTName ast pfx s = pfx ++
     Nothing -> s
     Just i  -> show i)
 
+defBang :: Q Bang
 defBang = bang noSourceUnpackedness noSourceStrictness
 
+strBangType :: (Q Bang, Q Type)
 strBangType = (defBang, conT $ mkName "String")
 
 mkCon   = conE . mkName . mkUpper
@@ -612,8 +614,9 @@ a2d ast nameAST G4S.Prod{G4S.pName = _A, G4S.patterns = ps} = let
             ]
 
   retType = let
+    rT :: G4S.PRHS -> Q Type
     rT G4S.PRHS{G4S.alphas = as, G4S.pDirective = dir}
-      = case (dir, vars as) of
+      = case (dir, (vars as :: [(G4S.ProdElem, Name, Q Exp)])) of
           (Just (G4S.UpperD d), vs) ->
               (do  i <- reify $ mkName d
                    (case i of
@@ -1102,8 +1105,8 @@ mkLRParser ast g =
     lr1Table' = M.toList tblInt -- _lr1Table'
     lr1S0'    = LR.convStateInt is $ LR.lr1Closure g $ LR.lr1S0 g
 
-    unitTy = [t| () |]
-    name' = [e| $(varE name) |] -- :: $(justGrammarTy' ast unitTy) |]
+    unitTy = [t| () |] :: Q Type
+    name' = [e| $(varE name) |] :: Q Exp -- :: $(justGrammarTy' ast unitTy) |]
   in do --D.traceM $ pshow' is
         D.traceM $ "lr1S0 = " ++ (pshow' $ LR.lr1S0 g)
         --D.traceM $ "lr1Table = " ++ (pshow' $ LR.lr1Table g)

--- a/src/Text/ANTLR/LL1.hs
+++ b/src/Text/ANTLR/LL1.hs
@@ -419,16 +419,13 @@ leftFactor = let
       | otherwise = []
 
     lcps :: [(Prime nts, ProdElems (Prime nts) t)]
-    lcps = [ (nts0, maximumBy (comparing length)
-                   [ lcp xs ys
-                   | Production _ (Prod _ xs) _ <- filter ((== nts0) . getLHS) (ps g)
-                   , Production _ (Prod _ ys) _ <- filter ((== nts0) . getLHS) (ps g)
-                   , xs /= ys
-                   ])
-           | nts0 <- toList $ ns g ]
-
-    --longest_lcps :: [(nts, ProdElems nts t)]
-    --longest_lcps = filter (not . null . snd) lcps
+    lcps = [ (nts0, maximumBy (comparing length) lcp_list)
+           | nts0 <- toList $ ns g
+           , let lcp_list = [ lcp xs ys
+                             | Production _ (Prod _ xs) _ <- filter ((== nts0) . getLHS) (ps g)
+                             , Production _ (Prod _ ys) _ <- filter ((== nts0) . getLHS) (ps g)
+                             , xs /= ys ]
+           , not (null lcp_list) ]
 
     incr :: Prime nts -> Prime nts
     incr (Prime (nts, i)) = Prime (nts, i + 1)

--- a/src/Text/ANTLR/MultiMap.hs
+++ b/src/Text/ANTLR/MultiMap.hs
@@ -21,8 +21,6 @@ import Text.ANTLR.Pretty
 import Data.Data (Data(..))
 import Language.Haskell.TH.Syntax (Lift(..))
 
-instance (Lift k, Lift v, Data k, Data v, Ord k, Ord v) => Lift (M.Map k v)
-
 -- | A multi 'Map' is a mapping from keys @k@ to sets of values @v@. A nice
 --   invariant to maintain while using a multi-map is to never have empty
 --   sets mapped to by some key.

--- a/src/Text/ANTLR/Set.hs
+++ b/src/Text/ANTLR/Set.hs
@@ -27,12 +27,12 @@ import qualified Data.Functor         as F
 import qualified Control.Applicative  as A
 import qualified Data.Foldable        as Foldable
 
-import Data.Map ( Map(..) )
+import Data.Map ( Map )
 import qualified Data.Map as M
 
 import qualified Data.HashSet as S
 import Data.HashSet as S
-  ( HashSet(..), member, toList, union
+  ( HashSet, member, toList, union
   , null, empty, map, size, singleton, insert
   , delete, unions, difference, intersection, foldl'
   , fromList
@@ -69,11 +69,8 @@ infixl 9 \\
 (\\) :: (Hashable a, Eq a) => Set a -> Set a -> Set a
 m1 \\ m2 = difference m1 m2
 
-instance (Hashable a, Eq a, Lift a) => Lift (S.HashSet a) where
-  lift set = [| fromList $(lift $ toList set) |]
-
-instance (Hashable k, Hashable v) => Hashable (Map k v) where
-  hashWithSalt salt mp = salt `hashWithSalt` M.toList mp
+-- Lift (HashSet a) provided by unordered-containers >= 0.2.20
+-- Hashable (Map k v) provided by hashable >= 1.3.4
 
 instance (Prettify a, Hashable a, Eq a) => Prettify (S.HashSet a) where
   prettify s = do

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
 # resolver: nightly-2019-04-10
-resolver: lts-16.15
+# resolver: lts-16.15  (GHC 8.8.4 — original)
+resolver: lts-22.43    # GHC 9.6.6
 
 packages:
 - .

--- a/test/KNOWN_FAILURES.md
+++ b/test/KNOWN_FAILURES.md
@@ -1,0 +1,30 @@
+# Known Test Failures
+
+This file documents test failures that are pre-existing (not regressions introduced by the
+`ghc-modernize` branch) or are due to known incomplete features.
+
+## `:lr` — `test_GLRInc`, `test_GLRPartial`
+
+**Status**: Pre-existing failures on master (GHC 8.8.4) and ghc-modernize (GHC 9.6.6).
+
+GLR incremental tokenization (`GLRInc`) and partial tokenization (`GLRPartial`) are
+experimental features explicitly documented as incomplete in the README. These tests
+exercise that experimental path and fail with parse errors on valid input.
+
+## `:unit` — compile failure in `PlusBug0.hs`
+
+**Status**: Pre-existing failure. The `[g4|...|]` quasiquoter generates `NT_LowerID_plus`
+in the data type definition but references `T_LowerID_plus` in pattern match code for the
+rule `plus : LowerID+ -> Plus`. This is an inconsistency in the quasiquoter's name
+generation for annotated terminal references (`+`, `*`, `?`).
+
+The test was added as part of issue #34 (regex annotation syntactic sugar) but the
+underlying naming bug was not fully resolved. This is a quasiquoter correctness issue
+unrelated to the GHC version upgrade.
+
+## Notes on `hashable` and `HashSet` ordering
+
+The `hashable` library changed its hashing algorithm between 1.3.x (GHC 8.x) and 1.4.x
+(GHC 9.x). Any code that relies on a specific iteration order of `HashSet`/`HashMap` may
+behave differently across GHC versions. One such bug was fixed in `Text.ANTLR.LL1.leftFactor`
+(the `maximumBy: empty structure` crash) as part of the `ghc-modernize` work.


### PR DESCRIPTION
- stack.yaml: bump resolver from lts-16.15 (GHC 8.8.4) to lts-22.43 (GHC 9.6.6)
- package.yaml: relax dependency upper bounds (containers, mtl, text, transformers, deepseq, haskell-src-meta); add StarIsType to default-extensions
- Text/ANTLR/Set.hs: remove HashSet(..) and Map(..) constructor wildcards (made private in unordered-containers 0.2.15+ / containers 0.7); remove orphan Lift and Hashable instances now provided by upstream libraries
- Text/ANTLR/MultiMap.hs: remove orphan Lift (Map k v) instance (now in containers 0.7)
- Language/ANTLR4/Boot/Syntax.hs: restore plain instance Lift Exp (TH 2.21 does not ship it; th-orphans is transitive but not imported here)
- Data/Set/Monad.hs: remove noncanonical mappend from Monoid instance
- Language/ANTLR4/Boot/Quote.hs: add type signatures to fix Quote m ambiguity from GHC 9.x TH API polymorphism (defBang, strBangType, rT, unitTy, name')
- Text/ANTLR/LL1.hs: fix maximumBy crash on empty list in leftFactor; root cause is hashable 1.4 changing HashSet iteration order between GHC versions
- test/KNOWN_FAILURES.md: document pre-existing failures (lr GLR tests, unit PlusBug0)

All suites pass except known pre-existing failures:
  PASS: simple, atn, ll, lr (19/21), lexer, unit0, sexpression, allstar, c
  SKIP: swift (known performance issue, pre-existing)
  FAIL (pre-existing): lr:test_GLRInc, lr:test_GLRPartial, unit:PlusBug0 compile error